### PR TITLE
Update cmake minimum required version to 3.17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.17)
 
 if(NOT CLANG_TIDY)
   find_package(Python3)


### PR DESCRIPTION
CMakeLists.txt uses variable ${CMAKE_CURRENT_FUNCTION_LIST_DIR} which was introduced in CMake version 3.17

See: 
https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_FUNCTION_LIST_DIR.html

If your CMake version is too low, you will get errors like:

`$ GEN=ninja make`
```

[313/454] Linking CXX shared library test/extension/loadable_extension_optimizer_demo.duckdb_extension
FAILED: test/extension/loadable_extension_optimizer_demo.duckdb_extension
: && /usr/bin/c++ -fPIC -O3 -DNDEBUG -O3 -DNDEBUG   -shared -Wl,-soname,loadable_extension_optimizer_demo.duckdb_extension -o test/extension/loadable_extension_optimizer_demo.duckdb_extension test/extension/CMakeFiles/loadable_extension_optimizer_demo_loadable_extension.dir/loadable_extension_optimizer_demo.cpp.o   && cd /tmp/duckdb/build/release/test/extension && /usr/bin/cmake -DEXTENSION=/tmp/duckdb/build/release/test/extension/loadable_extension_optimizer_demo.duckdb_extension -DPLATFORM_FILE=/tmp/duckdb/build/release/duckdb_platform_out -DDUCKDB_VERSION="4476a915db" -DEXTENSION_VERSION="default-version" -DNULL_FILE=/scripts/null.txt -P /scripts/append_metadata.cmake
CMake Error: Error processing file: /scripts/append_metadata.cmake
[344/454] Building CXX object src/execution/expression_executor/CMakeFiles/duckdb_expression_executor.dir/ub_duckdb_expression_executor.cpp.o
ninja: build stopped: subcommand failed.
make: *** [Makefile:290: release] Error 1
```